### PR TITLE
Fix entities not taking first-time damage

### DIFF
--- a/src/main/java/arekkuusu/betterhurttimer/common/Events.java
+++ b/src/main/java/arekkuusu/betterhurttimer/common/Events.java
@@ -85,7 +85,7 @@ public class Events {
 
         if (!data.canApply()) {
             float lastAmount = event.getAmount();
-            if (Double.compare(data.lastHurtAmount + BHTConfig.CONFIG.damageFrames.nextAttackDamageDifference, event.getAmount()) > 0) {
+            if (data.lastHurtAmount == 0 || Double.compare(data.lastHurtAmount + BHTConfig.CONFIG.damageFrames.nextAttackDamageDifference, event.getAmount()) > 0) {
                 if (BHTConfig.CONFIG.damageFrames.nextAttackDamageDifferenceApply) {
                     event.setAmount(lastAmount - Math.max(0, (float) data.lastHurtAmount));
                 }


### PR DESCRIPTION
Fixes the following circumstance (#35):
As the last hurt amount is initially set to 0 in HurtSourceData, the comparison of the last and current damage doesn't apply and results in no damage for the entity.

Possibly applicable to all versions of the mod.