### PR TITLE
Better approach to detect first-time damage

### DIFF
--- a/src/main/java/arekkuusu/betterhurttimer/api/capability/data/HurtSourceData.java
+++ b/src/main/java/arekkuusu/betterhurttimer/api/capability/data/HurtSourceData.java
@@ -4,7 +4,7 @@ public class HurtSourceData {
 
     public final HurtSourceInfo info;
     public double lastHurtAmount;
-    public int lastHurtTick;
+    public int lastHurtTick = -1;
 
     public HurtSourceData(HurtSourceInfo info) {
         this.info = info;

--- a/src/main/java/arekkuusu/betterhurttimer/common/Events.java
+++ b/src/main/java/arekkuusu/betterhurttimer/common/Events.java
@@ -82,10 +82,11 @@ public class Events {
         if (!optional.isPresent()) return;
 
         HurtSourceData data = optional.orElseThrow(UnsupportedOperationException::new);
+        if (data.lastHurtTick == -1) return; // First-time damage
 
         if (!data.canApply()) {
             float lastAmount = event.getAmount();
-            if (data.lastHurtAmount == 0 || Double.compare(data.lastHurtAmount + BHTConfig.CONFIG.damageFrames.nextAttackDamageDifference, event.getAmount()) > 0) {
+            if (Double.compare(data.lastHurtAmount + BHTConfig.CONFIG.damageFrames.nextAttackDamageDifference, event.getAmount()) > 0) {
                 if (BHTConfig.CONFIG.damageFrames.nextAttackDamageDifferenceApply) {
                     event.setAmount(lastAmount - Math.max(0, (float) data.lastHurtAmount));
                 }


### PR DESCRIPTION
Instead of checking `lastHurtAmount` which legitimately can be 0, `lastHurtTick` is initialized with -1 instead to reliably detect first-time damage. This fixes occasions of damage spam caused by my previous implementation which did bypass the `damageSource` config by accident.